### PR TITLE
Adding database initialization variables in .env, root user, and new config value for max appts returned by appts query

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A `.env` environment variables file must also be added to the project root direc
 * `DB_SETUP_MAX_TFU_PER_APPT`: Initial `config` table value for `maxTFUPerAppt`
 * `DB_SETUP_ARRIVAL_WINDOW_LENGTH`: Initial `config` table value for `arrivalWindowLength` *must be `5`, `10`, `15`, `30`, or `60`*
 * `DB_SETUP_APPTS_QUERY_MAX_COUNT`: Initial `config` table value for `apptsQueryMaxCount`
+* `ROOT_USER_PW`: Password for the initial root user
 
 ### Installation
 Install dependencies
@@ -72,6 +73,8 @@ yarn setup:dev
 ```
 
 ### Production
+
+#### Setup
 Setup the database tables (`users`, `restrictions`, `appts`, `actions`, `config`) *first time only*
 
 ```shell
@@ -80,8 +83,13 @@ yarn setup
 
 **Note:** Running `yarn setup` will drop all existing database tables (it will warn you and ask for confirmation), so *only run if looking for a fresh start.*
 
-This script will also create a single entry in the `config` table using the `DB_SETUP` prefixed environment variables from `.env`. The application can not run unless there is an entry in the "config" table with values for each field.
+This script will create a single entry in the `config` table using the `DB_SETUP` prefixed environemnt variables from `.env`. The application can not run unless there is an entry in the `config` table with values for each field.
 
+The script will also create a single admin user named `root` with the password defined in the `ROOT_USER_PW` environment variable.
+
+This user cannot be queried, deleted, or modified using the API. It is intended to be used to confirm and promote to admin the desired system administrator after he/she has registered. After this, `root` should not be used.
+
+#### Starting the server
 Start the server (with `NODE_ENV` set to `production`)
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ A `.env` environment variables file must also be added to the project root direc
 * `PLIVO_AUTH_ID`: Plivo auth ID (SMS sending)
 * `PLIVO_AUTH_TOKEN`: Plivo auth (SMS sending)
 * `PLIVO_SRC_NUM`: Plivo sender mobile number (SMS sending)
+* `DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR`: Initial `config` table value for `defaultAllowedApptsPerHour`
+* `DB_SETUP_MAX_TFU_PER_APPT`: Initial `config` table value for `maxTFUPerAppt`
+* `DB_SETUP_ARRIVAL_WINDOW_LENGTH`: Initial `config` table value for `arrivalWindowLength` *must be `5`, `10`, `15`, `30`, or `60`*
+* `DB_SETUP_APPTS_QUERY_MAX_COUNT`: Initial `config` table value for `apptsQueryMaxCount`
 
 ### Installation
 Install dependencies
@@ -68,13 +72,15 @@ yarn setup:dev
 ```
 
 ### Production
-Setup the database tables (users, restrictions, appts, actions, config) *first time only*
+Setup the database tables (`users`, `restrictions`, `appts`, `actions`, `config`) *first time only*
 
 ```shell
 yarn setup
 ```
 
 **Note:** Running `yarn setup` will drop all existing database tables (it will warn you and ask for confirmation), so *only run if looking for a fresh start.*
+
+This script will also create a single entry in the `config` table using the `DB_SETUP` prefixed environment variables from `.env`. The application can not run unless there is an entry in the "config" table with values for each field.
 
 Start the server (with `NODE_ENV` set to `production`)
 

--- a/lib/data/models/config.js
+++ b/lib/data/models/config.js
@@ -14,6 +14,10 @@ const Config = sequelize.define('config', {
   arrivalWindowLength: {
     type: Sequelize.INTEGER,
     allowNull: false
+  },
+  apptsQueryMaxCount: {
+    type: Sequelize.INTEGER,
+    allowNull: false
   }
 },
 {

--- a/lib/data/setup-scripts/setup-dev.js
+++ b/lib/data/setup-scripts/setup-dev.js
@@ -7,6 +7,20 @@ const readline = require('readline');
 const sequelize = require('../sequelize');
 const { Action, Appt, Config, Restriction, User } = require('../models');
 
+const {
+  DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR,
+  DB_SETUP_MAX_TFU_PER_APPT,
+  DB_SETUP_ARRIVAL_WINDOW_LENGTH,
+  DB_SETUP_APPTS_QUERY_MAX_COUNT
+} = process.env;
+
+const sampleConfig = {
+  maxTFUPerAppt: DB_SETUP_MAX_TFU_PER_APPT,
+  defaultAllowedApptsPerHour: DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR,
+  arrivalWindowLength: DB_SETUP_ARRIVAL_WINDOW_LENGTH,
+  apptsQueryMaxCount: DB_SETUP_APPTS_QUERY_MAX_COUNT
+};
+
 const sampleUsers = [
   {
     email: 'robert@gmail.com',
@@ -57,17 +71,6 @@ const sampleUsers = [
     confirmed: true,
     emailVerified: true,
     reminderSetting: 'EMAIL'
-  },
-  {
-    email: 'jbrady@kcus.org',
-    password: bcrypt.hashSync('000000', 10),
-    role: 'OPERATOR',
-    company: 'KCUS',
-    name: 'Jacob Brady',
-    mobileNumber: '12074007898',
-    confirmed: false,
-    emailVerified: false,
-    reminderSetting: 'BOTH'
   }
 ];
 
@@ -136,7 +139,7 @@ const sampleAppts = [
     arrivalWindowLength: 15
   },
   {
-    userEmail: 'jbrady@kcus.org',
+    userEmail: 'jacob@jdbrady.info',
     timeSlot: {
       hour: 10,
       date: (() => {
@@ -229,12 +232,6 @@ const sampleRestrictions = [
     gateCapacity: 2
   }
 ];
-
-const sampleConfig = {
-  maxTFUPerAppt: 40,
-  defaultAllowedApptsPerHour: 10,
-  arrivalWindowLength: 5
-};
 
 const createTables = async () => sequelize.sync({ force: true });
 const addUsers = () => Promise.all(sampleUsers.map(async user => User.create(user)));

--- a/lib/data/setup-scripts/setup-prod.js
+++ b/lib/data/setup-scripts/setup-prod.js
@@ -1,16 +1,18 @@
 require('dotenv').config();
 
+const bcrypt = require('bcrypt');
 const chalk = require('chalk');
 const readline = require('readline');
 
 const sequelize = require('../sequelize');
-const { Config } = require('../models');
+const { Config, User } = require('../models');
 
 const {
   DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR,
   DB_SETUP_MAX_TFU_PER_APPT,
   DB_SETUP_ARRIVAL_WINDOW_LENGTH,
-  DB_SETUP_APPTS_QUERY_MAX_COUNT
+  DB_SETUP_APPTS_QUERY_MAX_COUNT,
+  ROOT_USER_PW
 } = process.env;
 
 const rl = readline.createInterface({
@@ -25,12 +27,24 @@ rl.question(chalk.yellow('Are you sure you wish to continue (y/N)?\n'), async (i
     console.log(chalk.yellow('🛠  Creating tables'));
     await sequelize.sync({ force: true });
 
-    console.log(chalk.yellow('⚙️ Adding base config'));
+    console.log(chalk.yellow('⚙️  Adding base config'));
     await Config.create({
       maxTFUPerAppt: DB_SETUP_MAX_TFU_PER_APPT,
       defaultAllowedApptsPerHour: DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR,
       arrivalWindowLength: DB_SETUP_ARRIVAL_WINDOW_LENGTH,
       apptsQueryMaxCount: DB_SETUP_APPTS_QUERY_MAX_COUNT
+    });
+
+    console.log(chalk.yellow('⚙️  Adding \'root\' user'));
+    await User.create({
+      email: 'root',
+      password: bcrypt.hashSync(ROOT_USER_PW, 10),
+      role: 'ADMIN',
+      name: 'root',
+      company: '',
+      confirmed: true,
+      emailVerified: true,
+      reminderSetting: 'NONE'
     });
 
     console.log(chalk.green('💫  Database setup complete'));

--- a/lib/data/setup-scripts/setup-prod.js
+++ b/lib/data/setup-scripts/setup-prod.js
@@ -4,7 +4,14 @@ const chalk = require('chalk');
 const readline = require('readline');
 
 const sequelize = require('../sequelize');
-require('../models');
+const { Config } = require('../models');
+
+const {
+  DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR,
+  DB_SETUP_MAX_TFU_PER_APPT,
+  DB_SETUP_ARRIVAL_WINDOW_LENGTH,
+  DB_SETUP_APPTS_QUERY_MAX_COUNT
+} = process.env;
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -17,6 +24,14 @@ rl.question(chalk.yellow('Are you sure you wish to continue (y/N)?\n'), async (i
   if (input.toLowerCase() === 'y' || input.toLowerCase() === 'yes') {
     console.log(chalk.yellow('🛠  Creating tables'));
     await sequelize.sync({ force: true });
+
+    console.log(chalk.yellow('⚙️ Adding base config'));
+    await Config.create({
+      maxTFUPerAppt: DB_SETUP_MAX_TFU_PER_APPT,
+      defaultAllowedApptsPerHour: DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR,
+      arrivalWindowLength: DB_SETUP_ARRIVAL_WINDOW_LENGTH,
+      apptsQueryMaxCount: DB_SETUP_APPTS_QUERY_MAX_COUNT
+    });
 
     console.log(chalk.green('💫  Database setup complete'));
 

--- a/lib/graphql/resolvers/checks.js
+++ b/lib/graphql/resolvers/checks.js
@@ -99,6 +99,10 @@ module.exports.isRoleOwnRoleCheck = (role, user) => {
   }
 };
 
+module.exports.isRootUserCheck = (email) => {
+  if (email === 'root') throw new Errors.NoUserError();
+};
+
 module.exports.isUserConfirmedCheck = (user) => {
   if (!user.confirmed) throw new Errors.UnconfirmedUserError();
 };

--- a/lib/graphql/resolvers/errors.js
+++ b/lib/graphql/resolvers/errors.js
@@ -100,6 +100,9 @@ module.exports = {
   TokenExpiredError: createError('TokenExpiredError', {
     message: 'The authentication token included in the request has expired'
   }),
+  TooManyAppointmentsError: createError('TooManyAppointmentsError', {
+    message: 'The appointments query yielded too many results to send'
+  }),
   UnconfirmedUserError: createError('UnconfirmedUserError', {
     message: 'Your account must be confirmed by an admin before you can log in'
   }),

--- a/lib/graphql/resolvers/mutation/change-user-email.js
+++ b/lib/graphql/resolvers/mutation/change-user-email.js
@@ -1,11 +1,13 @@
 const logger = require('../../../logging/logger');
 const { sendEmailChangedNotice } = require('../../../messaging/email/send-email');
 const { isAdminResolver } = require('../auth');
-const { doesUserExistCheck, userDoesntExistCheck } = require('../checks');
+const { isRootUserCheck, doesUserExistCheck, userDoesntExistCheck } = require('../checks');
 
 // changeUserEmail(input: ChangeUserEmailInput!): String
 const changeUserEmail = isAdminResolver.createResolver(
   async (_, { input: { currEmail, newEmail } }, { User }) => {
+    isRootUserCheck(currEmail);
+
     const targetUser = await doesUserExistCheck(currEmail, User);
     await userDoesntExistCheck(newEmail, User);
 

--- a/lib/graphql/resolvers/mutation/delete-user.js
+++ b/lib/graphql/resolvers/mutation/delete-user.js
@@ -1,9 +1,11 @@
 const { isAdminResolver } = require('../auth');
-const { doesUserExistCheck, isUserNotSelfCheck } = require('../checks');
+const { doesUserExistCheck, isUserNotSelfCheck, isRootUserCheck } = require('../checks');
 
 // deleteUser(input: DeleteUserInput!): String
 const deleteUser = isAdminResolver.createResolver(
   async (_, { input: { email } }, { user, User }) => {
+    isRootUserCheck(email);
+    
     const targetUser = await doesUserExistCheck(email, User);
     isUserNotSelfCheck(targetUser.email, user); // can't delete yourself
 

--- a/lib/graphql/resolvers/mutation/update-user.js
+++ b/lib/graphql/resolvers/mutation/update-user.js
@@ -1,10 +1,12 @@
 const { isAuthenticatedResolver } = require('../auth');
-const { doesUserExistCheck, isUserSelfCheck, isRoleOwnRoleCheck } = require('../checks');
+const { isRootUserCheck, doesUserExistCheck, isUserSelfCheck, isRoleOwnRoleCheck } = require('../checks');
 const { isAdmin } = require('../helpers');
 
 // updateUser(input: UpdateUserInput!): User
 const updateUser = isAuthenticatedResolver.createResolver(
   async (_, { input: { email, ...details } }, { user, User }) => {
+    isRootUserCheck(email);
+    
     const targetUser = await doesUserExistCheck(email, User);
 
     if (!isAdmin(user)) {

--- a/lib/graphql/resolvers/query/appts.js
+++ b/lib/graphql/resolvers/query/appts.js
@@ -2,10 +2,11 @@ const Op = require('sequelize').Op;
 const { startOfDay, addDays } = require('date-fns');
 
 const { isAuthenticatedResolver } = require('../auth');
+const { TooManyAppointmentsError } = require('../errors');
 
 // appts(input: ApptsInput!): [Appointment]
 const appts = isAuthenticatedResolver.createResolver(
-  async (_, { input: { startDate, endDate, where = {} } }, { Appt, Action }) => {
+  async (_, { input: { startDate, endDate, where = {} } }, { Appt, Action, Config }) => {
     const { userEmail, actionType } = where;
 
     let actionTypeFilterApptIds;
@@ -19,7 +20,9 @@ const appts = isAuthenticatedResolver.createResolver(
       }
     }
 
-    return Appt.findAll({
+    const config = await Config.findOne();
+
+    const options = {
       where: { 
         ...((startDate || endDate) && { 
           timeSlotDate: {
@@ -29,8 +32,15 @@ const appts = isAuthenticatedResolver.createResolver(
         }),
         ...(userEmail && { userEmail }),
         ...(actionType && { id: { [Op.or]: actionTypeFilterApptIds } })
-      }
-    });
+      },
+      limit: config.apptsQueryMaxCount + 1
+    };
+
+    const { count, rows } = await Appt.findAndCountAll(options);
+
+    if (count > config.apptsQueryMaxCount) throw new TooManyAppointmentsError();
+
+    return rows;
   }
 );
 

--- a/lib/graphql/resolvers/query/user.js
+++ b/lib/graphql/resolvers/query/user.js
@@ -2,7 +2,10 @@ const { isAdminResolver } = require('../auth');
 
 // user(email: UserInput!): User
 const user = isAdminResolver.createResolver(
-  async (_, { input: { email } }, { User }) => User.findByPk(email)
+  async (_, { input: { email } }, { User }) => {
+    if (email === 'root') return null;
+    return User.findByPk(email);
+  }
 );
 
 module.exports = user;

--- a/lib/graphql/resolvers/query/users.js
+++ b/lib/graphql/resolvers/query/users.js
@@ -1,8 +1,19 @@
+const { Op } = require('sequelize');
+
 const { isAdminResolver } = require('../auth');
 
 // users(input: UsersInput!): [User]
 const users = isAdminResolver.createResolver(
-  async (_, { input: { where } }, { User }) => User.findAll({ where })
+  async (_, { input: { where } }, { User }) => (
+    User.findAll({
+      where: {
+        ...where,
+        email: {
+          [Op.ne]: 'root'
+        }
+      }
+    })
+  )
 );
 
 module.exports = users;

--- a/lib/graphql/schema/query.js
+++ b/lib/graphql/schema/query.js
@@ -15,7 +15,6 @@ const Query = `
   }
 
   input UsersWhere {
-    email: String
     name: String
     role: UserRole
     company: String

--- a/lib/messaging/email/send-email.js
+++ b/lib/messaging/email/send-email.js
@@ -41,7 +41,7 @@ const createMailOptionsBuilder = (subject, templateFile) => {
 
 const buildSendFunc = (title, templateFile) => {
   if (process.env.NODE_ENV === 'test') {
-    return (toEmail, data) => null;
+    return () => null;
   }
 
   return async (toEmail, data) => (

--- a/test/integration/checks.test.js
+++ b/test/integration/checks.test.js
@@ -7,7 +7,7 @@ const { Config } = require('../../lib/data/models');
 describe('isValidNumContainersCheck', () => {
   beforeAll(async done => {
     await sequelize.sync({ force: true });
-    await Config.create({ defaultAllowedApptsPerHour: 1, maxTFUPerAppt: 40, arrivalWindowLength: 5 });
+    await Config.create({ defaultAllowedApptsPerHour: 1, maxTFUPerAppt: 40, arrivalWindowLength: 5, apptsQueryMaxCount: 500 });
     done();
   });
 

--- a/test/integration/helpers.test.js
+++ b/test/integration/helpers.test.js
@@ -25,13 +25,13 @@ describe('Appointment slot availability', () => {
   });
 
   test('Slot is available when no restrictions or no other appts in this slot and default allow appts per hour is greater than 0', async () => {
-    await Config.create({ defaultAllowedApptsPerHour: 1, maxTFUPerAppt: 40, arrivalWindowLength: 5 });
+    await Config.create({ defaultAllowedApptsPerHour: 1, maxTFUPerAppt: 40, arrivalWindowLength: 5, apptsQueryMaxCount: 500 });
     const isAvailable = await slotAvailability(timeSlot, Appt, Config, Restriction, RestrictionTemplate);
     expect(isAvailable).toEqual(true);
   });
 
   test('Slot is unavailable when no restrictions or no other appts in this slot and default allow appts per hour is 0', async () => {
-    await Config.create({ defaultAllowedApptsPerHour: 0, maxTFUPerAppt: 40, arrivalWindowLength: 5 });
+    await Config.create({ defaultAllowedApptsPerHour: 0, maxTFUPerAppt: 40, arrivalWindowLength: 5, apptsQueryMaxCount: 500 });
     const isAvailable = await slotAvailability(timeSlot, Appt, Config, Restriction, RestrictionTemplate);
     expect(isAvailable).toEqual(false);
   });
@@ -89,7 +89,7 @@ describe('Appointment slot availability', () => {
   });
 
   test('Slot is subject to template restrictions only when there is an applied restriction template with a value for the given slot', async () => {
-    await Config.create({ defaultAllowedApptsPerHour: 1, maxTFUPerAppt: 40, arrivalWindowLength: 5 });
+    await Config.create({ defaultAllowedApptsPerHour: 1, maxTFUPerAppt: 40, arrivalWindowLength: 5, apptsQueryMaxCount: 500 });
     const template = await RestrictionTemplate.create({ name: 'TEST TEMPLATE', isApplied: false });
     await Restriction.create({
       dayOfWeek: timeSlotDayOfWeek,

--- a/test/integration/mutation/add-appt.test.js
+++ b/test/integration/mutation/add-appt.test.js
@@ -14,7 +14,7 @@ const authToken = jwt.sign({
   userEmail: 'test@test',
   userRole: 'ADMIN'
 }, process.env.SECRET_KEY);
-
+ 
 const validAddApptInput = `
   {
     timeSlot: {
@@ -35,7 +35,7 @@ const validAddApptInput = `
 describe('addAppt Mutation', () => {
   beforeEach(done => {
     sequelize.sync({ force: true })
-      .then(() => Config.create({ defaultAllowedApptsPerHour: 10, maxTFUPerAppt: 40, arrivalWindowLength: 5 }))
+      .then(() => Config.create({ defaultAllowedApptsPerHour: 10, maxTFUPerAppt: 40, arrivalWindowLength: 5, apptsQueryMaxCount: 500 }))
       .then(() => User.create({ email: 'test@test', name: 'test', company: 'test', password: 'test' }))
       .then(() => done());
   });

--- a/test/integration/query/appts.test.js
+++ b/test/integration/query/appts.test.js
@@ -3,7 +3,7 @@ const jwt = require('jsonwebtoken');
 
 const server = require('../../../lib/server');
 const sequelize = require('../../../lib/data/sequelize');
-const { User, Appt, Action } = require('../../../lib/data/models');
+const { User, Appt, Action, Config } = require('../../../lib/data/models');
 
 const newAppt1Id = '12345678';
 const newAppt2Id = '910111213';
@@ -84,6 +84,14 @@ describe('appts Query', () => {
             emptyForCityFormNumber: 'form2i38r923r'
           }
         ]);
+      })
+      .then(() => {
+        return Config.create({
+          arrivalWindowLength: 5,
+          maxTFUPerAppt: 40,
+          defaultAllowedApptsPerHour: 5,
+          apptsQueryMaxCount: 500
+        });
       }).then(() => done());
   });
 
@@ -93,6 +101,8 @@ describe('appts Query', () => {
       done();
     });
   });
+
+  // TODO test that appts can't return more than the `apptsQueryMaxCount`
 
   test('appts query can return all appts in the database', done => {
     request(server)

--- a/test/integration/query/arrival-window-length.test.js
+++ b/test/integration/query/arrival-window-length.test.js
@@ -13,7 +13,8 @@ describe('arrivalWindowLength Query', () => {
     await Config.create({
       arrivalWindowLength: testArrivalWindowLength,
       maxTFUPerAppt: 40,
-      defaultAllowedApptsPerHour: 5
+      defaultAllowedApptsPerHour: 5,
+      apptsQueryMaxCount: 500
     });
     done();
   });

--- a/test/integration/query/default-allowed-appts-per-hour.test.js
+++ b/test/integration/query/default-allowed-appts-per-hour.test.js
@@ -13,7 +13,8 @@ describe('defaultAllowedApptsPerHour Query', () => {
     await Config.create({
       arrivalWindowLength: 5,
       maxTFUPerAppt: 40,
-      defaultAllowedApptsPerHour: testDefaultAllowedApptsPerHour
+      defaultAllowedApptsPerHour: testDefaultAllowedApptsPerHour,
+      apptsQueryMaxCount: 500
     });
     done();
   });


### PR DESCRIPTION
Added a user named (email) 'root' which is created by the production database setup script and updated the user, users, updateUser...etc. queries/mutation to exclude this user. 

Added new `config` table value `apptsQueryMaxCount` which restricts the number of appts that can be return. This is the poor man's pagination but fixes #12.

Added the following environment variables (noted in project root README):

* `DB_SETUP_DEFAULT_ALLOWED_APPTS_PER_HOUR`: Initial `config` table value for `defaultAllowedApptsPerHour`
* `DB_SETUP_MAX_TFU_PER_APPT`: Initial `config` table value for `maxTFUPerAppt`
* `DB_SETUP_ARRIVAL_WINDOW_LENGTH`: Initial `config` table value for `arrivalWindowLength` *must be `5`, `10`, `15`, `30`, or `60`*
* `DB_SETUP_APPTS_QUERY_MAX_COUNT`: Initial `config` table value for `apptsQueryMaxCount`
* `ROOT_USER_PW`: Password for the initial root user



